### PR TITLE
reducer documentation / fix return value in example code

### DIFF
--- a/src/dom_top/core.clj
+++ b/src/dom_top/core.clj
@@ -1009,7 +1009,7 @@
                           (recur (+ sum x) (inc count)))
                         [:final acc])
                [4 1 9 9 9])
-    ; => [:early 5]"
+    ; => [:final [:early 5]]"
   [accumulator-bindings element-bindings body & [final]]
   (assert (even? (count accumulator-bindings)))
   (assert (= 1 (count element-bindings)))


### PR DESCRIPTION
The documented return value  in the last example doesn't match the description and code, "[:early 5]" should be "[:final [:early 5]]"
Thank you for this great macro!